### PR TITLE
Add Sepolia, Rename method metamask_watchAsset to wallet_watchAsset

### DIFF
--- a/src/AddTokenPanel.jsx
+++ b/src/AddTokenPanel.jsx
@@ -124,7 +124,7 @@ class AddTokenPanel extends Component {
             onClick={async (event) => {
               const provider = await detectEthereumProvider()
               provider.sendAsync({
-                method: 'metamask_watchAsset',
+                method: 'wallet_watchAsset',
                 params: {
                   "type": "ERC20",
                   "options": {

--- a/src/SwitchNetworkNotice.jsx
+++ b/src/SwitchNetworkNotice.jsx
@@ -19,6 +19,9 @@ const nameForNetwork = (network) => {
     case '42': // kovan test net
       name = 'The Kovan Test Network'
       break
+    case '11155111': // sepolia test net
+      name = 'The Sepolia Test Network'
+      break
     default:
       name = `Network #${network}`
   }


### PR DESCRIPTION
`metamask_watchAsset` works in the chrome extension but not in MetaMask mobile.  
also, this PR added sepolia test net for the `nameForNetwork`.
  
Related issue: https://github.com/MetaMask/metamask-mobile/issues/1053 
and the correct method specified in https://eips.ethereum.org/EIPS/eip-747